### PR TITLE
Actually flush measurements batch when batch size is reached.

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -286,7 +286,7 @@ var flushStats = function libratoFlush(ts, metrics) {
     // Post measurements and clear arrays if past batch size
     if (measurements.length >= maxBatchSize || writeToLegacy && counters.length + gauges.length >= maxBatchSize) {
       postMetrics(measureTime, gauges, counters, measurements);
-      if (measurements >= maxBatchSize) {
+      if (measurements.length >= maxBatchSize) {
         measurements = [];
       }
       if (counters.length + gauges.length >= maxBatchSize) {


### PR DESCRIPTION
This was resulting in ever increasing batches being sent and not resetting the batch when the max batch size is reached.